### PR TITLE
Renamed from Phrase Bingo to Kati Bingo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title>Phrase Bingo</title>
+    <title>Kati Bingo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Tailwind (CDN) -->
     <script src="https://cdn.tailwindcss.com"></script>
@@ -17,7 +17,7 @@
     <div id="loginPanel" class="max-w-md mx-auto mt-24 p-6 bg-white/80 backdrop-blur rounded-2xl shadow-xl border border-slate-200 animate-fade-in">
         <div class="flex items-center gap-3 mb-4">
             <div class="h-10 w-10 rounded-xl bg-indigo-600/90 flex items-center justify-center text-white text-xl">B</div>
-            <h1 class="text-2xl font-semibold tracking-tight">Join Phrase Bingo</h1>
+            <h1 class="text-2xl font-semibold tracking-tight">Join Kati Bingo</h1>
         </div>
         <p class="text-sm text-slate-500 mb-4">Enter a display name (no account needed).</p>
         <form id="loginForm" class="space-y-3">
@@ -108,6 +108,14 @@
     </div>
 </div>
 
+<!-- Footer -->
+<footer class="text-center text-xs text-slate-500 py-4 mt-8">
+    <div>Kati Bingo &copy; 2025</div>
+    <div>Made with ❤️ by fans.</div>
+    <div>This website is a fan-created project and is not affiliated with, endorsed by, or officially connected to Kati Morton in any way.<br>
+        All content is created for entertainment purposes only. For Kati Morton’s official content, please visit<br>
+        <a href="https://katimorton.com/">KatiMorton.com</a></div>
+</footer>
 <!-- Confetti canvas -->
 <canvas id="confetti" class="pointer-events-none fixed inset-0 w-full h-full hidden"></canvas>
 


### PR DESCRIPTION
This pull request updates the branding of the application from "Phrase Bingo" to "Kati Bingo" and adds a new footer to clarify the fan-created nature of the site. The main changes are focused on updating the name throughout the user interface and providing proper attribution and disclaimers.

Branding updates:

* Changed the application title in the `<title>` tag from "Phrase Bingo" to "Kati Bingo" in `public/index.html`.
* Updated the main heading on the login panel from "Join Phrase Bingo" to "Join Kati Bingo" in `public/index.html`.

Legal and attribution:

* Added a new footer to `public/index.html` that includes copyright information, a fan disclaimer, and a link to Kati Morton's official website.Added disclaimer at the bottom